### PR TITLE
Reference Postgres by website title page in humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -87,7 +87,7 @@ TECHNOLOGIES
 
 Supabase would not be possible without the work of some other amazing open source contributors.
 
-- Postgres - https://www.postgresql.org/docs/devel/git.html
+- Postgres - https://www.postgresql.org/
 - PostgREST - https://github.com/PostgREST
 - Kong - https://github.com/kong/
 - Next.js - https://nextjs.org/


### PR DESCRIPTION
We reference other open source projects by home page or GitHub page. Why do we reference PostgreSQL by its documentation page about git? I propose to change the reference to the title website page.